### PR TITLE
Missing s on posts.

### DIFF
--- a/Chapter01/mysite/blog/templates/blog/post/list.html
+++ b/Chapter01/mysite/blog/templates/blog/post/list.html
@@ -4,7 +4,7 @@
  
 {% block content %}
   <h1>My Blog</h1>
-  {% for post in post %}
+  {% for post in posts %}
     <h2>
       <a href="{{ post.get_absolute_url }}">
         {{ post.title }}


### PR DESCRIPTION
Without this 's' the blog posts don't show up. The book had this code right on page 37.